### PR TITLE
fix: Activate Apache modules by default

### DIFF
--- a/provision/scripts/apache.sh
+++ b/provision/scripts/apache.sh
@@ -92,6 +92,15 @@ else
     print_error "Error trying to enable public_html.conf"
     exit 1
 fi
+
+a2enmod rewrite headers expires include
+if [ $? -eq 0 ]; then
+    print_success "Activated modules: rewrite, headers, expires and include"
+else
+    print_error "Error activating additional modules"
+fi
+search_apache_mods_enabled 
+echo ""
 print_success "✅ Apache configured"
 echo ""
 

--- a/provision/scripts/bash-utils.sh
+++ b/provision/scripts/bash-utils.sh
@@ -146,6 +146,28 @@ run_apt_command() {
 }
 
 # ============================================
+# APACHE MODS
+# ============================================
+
+# Search for enabled modules
+search_apache_mods_enabled() {
+    
+    #ls /etc/apache2/mods-enabled/ | grep -E "(rewrite|headers|expires|include|ipblock)\.load"
+
+    # Or to see both, enabled and available
+    for modulo in rewrite headers expires include proxy nomy; do
+        echo -n "Module $modulo: "
+        if [ -f /etc/apache2/mods-enabled/${modulo}.load ]; then
+            print_success "ACTIVATED"
+        elif [ -f /etc/apache2/mods-available/${modulo}.load ]; then
+            print_warning "AVAILABLE (but not activated)"
+        else
+            print_error "NOT INSTALLED"
+        fi
+    done
+}
+
+# ============================================
 # CLEANUP FUNCTIONS
 # ============================================
 


### PR DESCRIPTION
- The following modules are now enabled:
  - rewrite
  - headers
  - expires
  - include
- New function `search_apache_mods_enabled` checks for enabled Apache modules

close: #18