### PR TITLE
Add Redis Commander with Apache reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Redis 7.2+](https://img.shields.io/badge/Redis-7.2+-DC382D.svg)](https://redis.io)
 [![phpMyAdmin](https://img.shields.io/badge/phpMyAdmin-5.2.x-orange.svg)](https://www.phpmyadmin.net)
 [![pgAdmin](https://img.shields.io/badge/pgAdmin-4-blue.svg)](https://www.pgadmin.org)
+[![Redis Commander](https://img.shields.io/badge/Redis%20Commander-0.9.x-D82C20.svg)](https://github.com/joeferner/redis-commander)
 [![Composer 2.x](https://img.shields.io/badge/Composer-2.x-89552D.svg)](https://getcomposer.org)
 
 > **Version:** 0.3.0  
@@ -41,7 +42,7 @@ Unlike generic LAMP boxes, **Pisco Box** provides:
 - Apache 2.4 + PHP-FPM
 - PHP: 8.4, 8.3, 8.0, 7.4, 7.0, 5.6
 - MariaDB, PostgreSQL 16 and Redis 7.2+
-- Database Management: phpMyAdmin and pgAdim
+- Database Management: phpMyAdmin, pgAdmin and Redis Commander
 - Development Tools: Git, Vim, Curl, Wget, and more
 - Time Zone: UTC, locale UTF-8
 - Synchronized Directories: Seamless host ↔ VM file sharing
@@ -128,6 +129,7 @@ After running `vagrant up`, verify your setup:
 1. Visit [http://localhost:8080/info-xdebug.php](http://localhost:8080/info-xdebug.php) → Xdebug info
 1. Visit [http://localhost:8080/phpmyadmin](http://localhost:8080/phpmyadmin) → phpMyAdmin dashboard
 1. Visit [http://localhost:8080/pgadmin4](http://localhost:8080/pgadmin4) → postgresql dashboard
+1. Visit [http://localhost:8080/redis](http://localhost:8080/redis) → Redis Commander dashboard
 1. Run `piscobox mysql login` → connects to MariaDB as `piscoboxuser`
 1. Run `sudo mysql` → connects to MariaDB as `root`
 1. Run `piscobox site create` → creates and serves `http://mysite.local`  
@@ -270,6 +272,20 @@ PING
 ```
 ---
 
+### Redis Commander
+
+Redis Commander is included as a web-based management UI for Redis.
+
+**Access:**
+- http://localhost:8080/redis
+
+**Notes:**
+- Redis Commander runs locally and is exposed via Apache reverse proxy.
+- During provisioning, npm may emit deprecation warnings related to upstream dependencies.
+  These warnings are expected and safe to ignore in the context of local development.
+
+---
+
 ## 🛠️ Technical Details
 
 ### PHP Configuration
@@ -376,9 +392,7 @@ sudo nano /etc/hosts
 # Edit C:\Windows\System32\drivers\etc\hosts as Administrator
 127.0.0.1 piscobox.local
 ```
-
 ---
-
 
 ## 🐛 Troubleshooting (Quick Guide)
 
@@ -406,6 +420,14 @@ sudo chown -R vagrant:vagrant /vagrant
 ```bash
 ./piscobox-sync-hosts.sh
 # Then flush DNS cache if needed
+```
+
+### 🔴 Redis Commander not loading
+
+```bash
+sudo systemctl status redis-commander
+sudo systemctl restart redis-commander
+sudo systemctl reload apache2
 ```
 
 ---

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.network "private_network", ip: "192.168.56.110"
   config.vm.network "forwarded_port", guest: 80, host: 8080
-  config.vm.network "forwarded_port", guest: 8081, host: 8081
 
   # ============================================================================
   # FOLDER SYNCHRONIZATION

--- a/provision/scripts/redis-commander.sh
+++ b/provision/scripts/redis-commander.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # =========================================="
-#  REDIS INSTALLATION
+#  REDIS COMMANDER INSTALLATION
 # =========================================="
 
 # Load utilities
@@ -17,13 +17,13 @@ print_header "REDIS INSTALLATION"
 print_success "Start at: $SCRIPT_START_TIME"
 echo ""
 
-print_step 1 5 "→ Installing Redis Commander..."
+print_step 1 6 "→ Installing Redis Commander..."
 
 # --------------------------------------------------
 # 1. Install NodeJS 18 LTS (NodeSource)
 # --------------------------------------------------
 if ! command -v node >/dev/null 2>&1; then
-    print_step 2 5 "→ Installing NodeJS 18 LTS..."
+    print_step 2 6 "→ Installing NodeJS 18 LTS..."
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
     run_apt_command "apt-get install -y nodejs"
 else
@@ -34,19 +34,19 @@ fi
 # 2. Install Redis Commander
 # --------------------------------------------------
 if ! command -v redis-commander >/dev/null 2>&1; then
-    print_step 3 5 "→ Installing Redis Commander..."
+    print_step 3 6 "→ Installing Redis Commander..."
     npm install -g redis-commander
 else
     print_success "Redis Commander already installed"
 fi
 
 # --------------------------------------------------
-# 3. Create systemd service
+# 3. Create systemd service (with url prefix)
 # --------------------------------------------------
 SERVICE_FILE="/etc/systemd/system/redis-commander.service"
 
 if [ ! -f "$SERVICE_FILE" ]; then
-    print_step 4 5 "→ Creating Redis Commander systemd service..."
+    print_step 4 6 "→ Creating Redis Commander systemd service..."
 
 cat <<EOF > "$SERVICE_FILE"
 [Unit]
@@ -55,7 +55,7 @@ After=network.target redis-server.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/redis-commander --bind 127.0.0.1 --port 8081
+ExecStart=/usr/bin/env redis-commander --bind 127.0.0.1 --port 8081 --url-prefix /redis
 Restart=always
 User=root
 Environment=REDIS_HOSTS=local:127.0.0.1:6379
@@ -71,9 +71,40 @@ else
 fi
 
 # --------------------------------------------------
-# 4. Start service
+# 4. Apache reverse proxy configuration
 # --------------------------------------------------
-print_step 5 5 "→ Restart Redis service..."
+APACHE_CONF="/etc/apache2/conf-available/redis-commander.conf"
+
+if [ ! -f "$APACHE_CONF" ]; then
+    print_step 5 6 "→ Configuring Apache reverse proxy for Redis Commander..."
+
+cat <<EOF > "$APACHE_CONF"
+# Redis Commander reverse proxy
+
+ProxyPreserveHost On
+
+ProxyPass        /redis http://127.0.0.1:8081/redis
+ProxyPassReverse /redis http://127.0.0.1:8081/redis
+
+RequestHeader set X-Forwarded-Proto "http"
+RequestHeader set X-Forwarded-Port "8080"
+
+<Location /redis>
+    Require all granted
+</Location>
+EOF
+
+    a2enmod proxy proxy_http headers
+    a2enconf redis-commander
+    systemctl reload apache2
+else
+    print_success "Apache reverse proxy already configured"
+fi
+
+# --------------------------------------------------
+# 5. Restart Redis Commander service
+# --------------------------------------------------
+print_step 6 6 "→ Restart Redis Commander service..."
 systemctl restart redis-commander
 
-print_success "Redis Commander installed and running"
+print_success "Redis Commander installed and available at /redis"

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -1,0 +1,1 @@
+<?php phpinfo(); ?>


### PR DESCRIPTION
Add Redis Commander as an administration tool for Redis within Pisco Box, securely exposing it through Apache as a reverse proxy.

- feature: Redis Commander integration for Redis instance management
- chore: Apache reverse proxy configuration to expose Redis Commander
- Documentation update (README) to reflect the new functionality