### PR TITLE
Fix PHP-FPM socket detection selecting oldest PHP service. Close #141

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ extra_data/
 
 # ignora todo lo que hay en public_html, excepto lo que hay en piscoweb
 public_html/*/
+public_html/index.php
 !public_html/piscoweb/
 !public_html/piscoweb/**
 

--- a/provision/scripts/bash-utils.sh
+++ b/provision/scripts/bash-utils.sh
@@ -297,24 +297,53 @@ detect_php_versions() {
 # --------------------------------------------
 # Detect PHP FPM socket
 # --------------------------------------------
+# detect_php_fpm_socket() {
+#   local service_regex="$1"
+#   local socket
+
+#   mapfile -t services < <(
+#     systemctl list-units --type=service --state=active \
+#       | awk '{print $1}' \
+#       | grep -E '^php[0-9]+\.[0-9]+-fpm\.service$'
+#   )
+
+#   for svc in "${services[@]}"; do
+#     if [[ -z "$service_regex" || "$svc" =~ $service_regex ]]; then
+#       socket="/run/php/${svc/.service/.sock}"
+#       if [[ -S "$socket" ]]; then
+#         echo "$socket"
+#         return 0
+#       fi
+#     fi
+#   done
+
+#   return 1
+# }
+
 detect_php_fpm_socket() {
+
   local service_regex="$1"
   local socket
 
   mapfile -t services < <(
     systemctl list-units --type=service --state=active \
       | awk '{print $1}' \
-      | grep -E '^php[0-9]+\.[0-9]+-fpm\.service$'
+      | grep -E '^php[0-9]+\.[0-9]+-fpm\.service$' \
+      | sort -V
   )
 
-  for svc in "${services[@]}"; do
-    if [[ -z "$service_regex" || "$svc" =~ $service_regex ]]; then
-      socket="/run/php/${svc/.service/.sock}"
-      if [[ -S "$socket" ]]; then
-        echo "$socket"
-        return 0
+  # recorrer desde la versión más alta
+  for (( idx=${#services[@]}-1 ; idx>=0 ; idx-- )) ; do
+      svc="${services[idx]}"
+
+      if [[ -z "$service_regex" || "$svc" =~ $service_regex ]]; then
+          socket="/run/php/${svc/.service/.sock}"
+
+          if [[ -S "$socket" ]]; then
+              echo "$socket"
+              return 0
+          fi
       fi
-    fi
   done
 
   return 1


### PR DESCRIPTION
## Fix incorrect PHP-FPM socket detection

This PR fixes an issue where `detect_php_fpm_socket()` could select an outdated PHP-FPM service (e.g. `php5.6-fpm.sock`) due to relying on the unordered output of `systemctl list-units`.

### Changes

* Detect all active `phpX.Y-fpm.service` units
* Sort them using `sort -V`
* Iterate from highest to lowest PHP version
* Preserve support for the optional regex parameter

This ensures the most appropriate PHP-FPM socket is selected while keeping backward compatibility with existing scripts such as `phpmyadmin.sh` and `phpmemcachedadmin.sh`.

### Result

`phpMyAdmin` and `phpMemcachedAdmin` provision correctly, now using the expected socket:

```
/run/php/php8.4-fpm.sock
```

Fixes #141.
