### PR TITLE
Centralize PHP_VERSIONS in global configuration

### DIFF
--- a/provision/config/piscobox-config.sh
+++ b/provision/config/piscobox-config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# --------------------------------------------------
+# Pisco Box Global Configuration
+# --------------------------------------------------
+
+# Supported PHP versions for provisioning
+PHP_VERSIONS=("8.4" "8.3")

--- a/provision/scripts/apache.sh
+++ b/provision/scripts/apache.sh
@@ -4,6 +4,9 @@
 # APACHE 2 INSTALLATION (multi-PHP support)
 # ============================================
 
+# Load global config
+source /vagrant/provision/config/piscobox-config.sh
+
 # Load utilities
 UTILS_FILE="/vagrant/provision/scripts/bash-utils.sh"
 [ -f "$UTILS_FILE" ] && source "$UTILS_FILE" || { echo "Error: Cannot load utilities"; exit 1; }
@@ -34,8 +37,6 @@ echo ""
 
 # Paso 3: Crear VirtualHosts por versión de PHP
 print_step 3 7 "Creating VirtualHosts for PHP versions..."
-PHP_VERSIONS=("8.4" "8.3" "8.0" "7.4" "7.0" "5.6")
-
 for ver in "${PHP_VERSIONS[@]}"; do
     SITE_DIR="/var/www/php${ver}"
     mkdir -p "$SITE_DIR"

--- a/provision/scripts/bash-utils.sh
+++ b/provision/scripts/bash-utils.sh
@@ -4,6 +4,9 @@
 # BASH UTILITIES FOR VAGRANT PROVISIONING
 # ============================================
 
+# Load global config
+source /vagrant/provision/config/piscobox-config.sh
+
 # Color definitions - consistent across all scripts
 TITLE_COLOR='\e[33m'       # Yellow for titles
 SUCCESS_COLOR='\e[96m'     # Bright cyan for success
@@ -260,12 +263,7 @@ get_php_versions() {
         PHP_VERSIONS+=("$ver")
       done
     fi
-  fi
-
-  # Último recurso: una lista por defecto (mantener compatibilidad con provisiones antiguas)
-  if [[ ${#PHP_VERSIONS[@]} -eq 0 ]]; then
-    PHP_VERSIONS=( "8.4" "8.3" "8.0" "7.4" "7.0" "5.6" )
-  fi
+  fi  
 }
 
 # --------------------------------------------

--- a/provision/scripts/php.sh
+++ b/provision/scripts/php.sh
@@ -4,6 +4,9 @@
 # PHP INSTALLATION (multi-version, PHP-FPM)
 # ============================================
 
+# Load global config
+source /vagrant/provision/config/piscobox-config.sh
+
 # Load utilities
 UTILS_FILE="/vagrant/provision/scripts/bash-utils.sh"
 [ -f "$UTILS_FILE" ] && source "$UTILS_FILE" || { echo "Error: Cannot load utilities"; exit 1; }
@@ -29,7 +32,6 @@ echo ""
 
 # Paso 2: Instalar todas las versiones de PHP con PHP-FPM
 print_step 2 7 "Installing PHP versions and FPM services..."
-PHP_VERSIONS=("8.4" "8.3" "8.0" "7.4" "7.0" "5.6")
 PHP_MODULES="mysql mbstring zip xml curl gd intl bz2 bcmath soap readline cli fpm"
 
 for ver in "${PHP_VERSIONS[@]}"; do


### PR DESCRIPTION
- Introduce `provision/config/piscobox-config.sh`
- Remove hardcoded `PHP_VERSIONS` from provisioning scripts
- Eliminate legacy fallback in `bash-utils.sh`
- Use shared configuration as single source of truth

Resolves issue #111 by removing duplicated definitions of `PHP_VERSIONS` across provisioning scripts and introducing a single source of truth.

### Changes

- Added a global configuration file:

```
provision/config/piscobox-config.sh
```

- Defined supported PHP versions in one place:

```bash
PHP_VERSIONS=("8.4" "8.3" "8.0" "7.4" "7.0" "5.6")
```

- Updated provisioning scripts to load the configuration:

```
provision/scripts/php.sh
provision/scripts/apache.sh
provision/scripts/bash-utils.sh
```

- Removed hardcoded `PHP_VERSIONS` definitions from those scripts.
- Removed the legacy fallback list in `bash-utils.sh` that duplicated the same values.

### Result

Provisioning scripts now rely on a single configuration source, reducing duplication and simplifying future updates to supported PHP versions.

### Testing

Provisioning was tested with a full rebuild:

```bash
vagrant destroy -f
vagrant up
```

All services and PHP versions were installed and configured successfully.