### PR TITLE
Prevent multiple loads of global provisioning config

### DIFF
--- a/provision/config/piscobox-config.sh
+++ b/provision/config/piscobox-config.sh
@@ -4,5 +4,13 @@
 # Pisco Box Global Configuration
 # --------------------------------------------------
 
+# Prevent loading the configuration multiple times
+# This file is intended to be sourced by provisioning scripts.
+if [[ -n "${PISCOBOX_CONFIG_LOADED:-}" ]]; then
+  return
+fi
+
+readonly PISCOBOX_CONFIG_LOADED=1
+
 # Supported PHP versions for provisioning
-PHP_VERSIONS=("8.4" "8.3")
+readonly PHP_VERSIONS=("8.4" "8.3" "5.6")


### PR DESCRIPTION
Adds a safe-loading guard to `provision/config/piscobox-config.sh` to ensure the global configuration is only loaded once per shell session.

This prevents accidental redefinitions when multiple provisioning scripts source the same configuration file.

**Changes:**

* Add `PISCOBOX_CONFIG_LOADED` guard
* Mark configuration variables as `readonly`

Closes #148
